### PR TITLE
WAV reader in library

### DIFF
--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -116,8 +116,8 @@ int compareFileExt(const char* filename, const char* ext) {
 
 //-1 = unsupported, 0 = WAV, 1+ = BRSTM lib formats
 int getFileExt(const char* filename) {
-    if(compareFileExt(filename,"WAV") == 0) return 0;
-    for(unsigned int f=1;f<BRSTM_formats_count;f++) {
+    //if(compareFileExt(filename,"WAV") == 0) return 0;
+    for(unsigned int f=0;f<BRSTM_formats_count;f++) {
         if(compareFileExt(filename,BRSTM_formats_short_usr_str[f]) == 0) return f;
     }
     //No match

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -48,6 +48,7 @@ struct Brstm {
     int16_t* PCM_blockbuffer[16];
     int PCM_blockbuffer_currentBlock = -1;
     bool getbuffer_useBuffer = true;
+    unsigned int audio_stream_format = 0; //See full description in brstm.h
 };
 ```
 

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -4,7 +4,7 @@ The BRSTM struct
 struct Brstm {
     //Byte order mark
     bool BOM;
-    //File type, 1 = BRSTM, see brstm.h file for full list
+    //File type, 0 = WAV, 1 = BRSTM, see brstm.h file for full list
     unsigned int  file_format;
     //Audio codec, 0 = PCM8, 1 = PCM16, 2 = DSPADPCM
     unsigned int  codec;
@@ -263,7 +263,7 @@ Console debug level:
 
 Encode ADPCM flag:
  0 = Use the ADPCM data from ADPCM_data (requires coefs in ADPCM_coefs[ch][coef])
- 1 = Encode PCM_samples into ADPCM
+ 1 = Use PCM_samples (and encode into ADPCM)
 
 Returns error code (>127) or warning code (<128)
 (see brstm_encode.h file for full list of error/warning codes). (unsigned char)
@@ -276,6 +276,3 @@ brstm_close(brstm); //This will delete the encoded data and PCM_samples
 delete brstm;
 
 ```
-
-### Editing headers
-I might add proper header editing some day (but I proably won't) so just do lossless conversions and change the data in your BRSTM struct.

--- a/src/lib/audio_decoder.h
+++ b/src/lib/audio_decoder.h
@@ -6,12 +6,17 @@
 //dataType will be 1 for disk streaming mode (fileData will be null) so brstm_getblock
 //will know to do disk streaming stuff instead of just getting a slice of fileData
 void brstm_decode_block(Brstm* brstmi,unsigned long b,unsigned int c,const unsigned char* fileData,bool dataType,int16_t** decodeDest,unsigned long decodeDestOff) {
-    unsigned long posOffset=0+(brstmi->blocks_size*c);
+    unsigned long posOffset;
+    if(brstmi->audio_stream_format == 0) {
+        posOffset = (brstmi->blocks_size*c);
+        posOffset+=b*(brstmi->blocks_size*brstmi->num_channels);
+    } else {
+        posOffset = 0;
+        posOffset+=b*(brstmi->blocks_size);
+    }
     unsigned long outputPos = 0; //position in decoded PCM samples output array
     
     unsigned long c_writtensamples = 0;
-    
-    posOffset+=b*(brstmi->blocks_size*brstmi->num_channels);
     
     //Read block
     unsigned int currentBlockSize    = brstmi->blocks_size;
@@ -21,13 +26,15 @@ void brstm_decode_block(Brstm* brstmi,unsigned long b,unsigned int c,const unsig
         currentBlockSize    = brstmi->final_block_size;
         currentBlockSamples = brstmi->final_block_samples;
     }
-    if(b>=brstmi->total_blocks-1 && c>0) {
-        //Go back to the previous position
-        posOffset-=brstmi->blocks_size*brstmi->num_channels;
-        //Go to the next block in position of first channel
-        posOffset+=brstmi->blocks_size*(brstmi->num_channels-c);
-        //Jump to the correct channel in the final block
-        posOffset+=brstmi->final_block_size_p*c;
+    if(brstmi->audio_stream_format != 1) {
+        if(b>=brstmi->total_blocks-1 && c>0) {
+            //Go back to the previous position
+            posOffset-=brstmi->blocks_size*brstmi->num_channels;
+            //Go to the next block in position of first channel
+            posOffset+=brstmi->blocks_size*(brstmi->num_channels-c);
+            //Jump to the correct channel in the final block
+            posOffset+=brstmi->final_block_size_p*c;
+        }
     }
     //Get data from just the current block
     //This function exists in the including file (brstm.h)
@@ -36,18 +43,32 @@ void brstm_decode_block(Brstm* brstmi,unsigned long b,unsigned int c,const unsig
     //Decode the audio
     if(brstmi->codec == 0) {
         //8 bit PCM
-        for(unsigned long sampleIndex=0;sampleIndex<currentBlockSamples;sampleIndex++) {
-            decodeDest[c][decodeDestOff+(outputPos++)] = ((int16_t)blockData[sampleIndex]-128)*256;
-            c_writtensamples++;
+        if(brstmi->audio_stream_format == 0) {
+            for(unsigned long sampleIndex=0;sampleIndex<currentBlockSamples;sampleIndex++) {
+                decodeDest[c][decodeDestOff+(outputPos++)] = ((int16_t)blockData[sampleIndex]-128)*256;
+                c_writtensamples++;
+            }
+        } else if(brstmi->audio_stream_format == 1) {
+            for(unsigned long sampleIndex=0;sampleIndex<currentBlockSamples;sampleIndex++) {
+                decodeDest[c][decodeDestOff+(outputPos++)] = ((int16_t)blockData[sampleIndex*brstmi->num_channels+c]-128)*256;
+                c_writtensamples++;
+            }
         }
     } else if(brstmi->codec == 1) {
         //16 bit PCM
-        for(unsigned long sampleIndex=0;sampleIndex<currentBlockSamples;sampleIndex++) {
-            decodeDest[c][decodeDestOff+(outputPos++)] = brstm_getSliceAsInt16Sample(blockData,sampleIndex*2,brstmi->BOM);
-            c_writtensamples++;
+        if(brstmi->audio_stream_format == 0) {
+            for(unsigned long sampleIndex=0;sampleIndex<currentBlockSamples;sampleIndex++) {
+                decodeDest[c][decodeDestOff+(outputPos++)] = brstm_getSliceAsInt16Sample(blockData,sampleIndex*2,brstmi->BOM);
+                c_writtensamples++;
+            }
+        } else if(brstmi->audio_stream_format == 1) {
+            for(unsigned long sampleIndex=0;sampleIndex<currentBlockSamples;sampleIndex++) {
+                decodeDest[c][decodeDestOff+(outputPos++)] = brstm_getSliceAsInt16Sample(blockData,sampleIndex*2*brstmi->num_channels+(c*2),brstmi->BOM);
+                c_writtensamples++;
+            }
         }
-    } else if(brstmi->codec == 2) {
-        //4 bit DSPADPCM
+    } else if(brstmi->codec == 2 && brstmi->audio_stream_format != 1) {
+        //4 bit DSPADPCM (does not support stream format 1)
         const unsigned char ps = blockData[0];
         const   signed int  yn1 = brstmi->ADPCM_hsamples_1[c][b], yn2 = brstmi->ADPCM_hsamples_2[c][b];
         

--- a/src/lib/brstm.h
+++ b/src/lib/brstm.h
@@ -13,26 +13,25 @@ const char* BRSTM_version_str = "v2.2.0";
 const char* brstm_getVersionString() {return BRSTM_version_str;}
 
 //Format information
-const unsigned int BRSTM_formats_count = 7;
+const unsigned int BRSTM_formats_count = 6;
 //File header magic words for each file format
-const char* BRSTM_formats_str[BRSTM_formats_count] = {"    ","RSTM","CSTM","FSTM","BWAV","OSTM","RIFF"};
+const char* BRSTM_formats_str[BRSTM_formats_count] = {"RIFF","RSTM","CSTM","FSTM","BWAV","OSTM"};
 //Offset to the audio offset information in each format (32 bit integer)
 //(doesn't have to be accurate, just enough to fit the entire file header before it)
-const unsigned int BRSTM_formats_audio_off_off[BRSTM_formats_count] = {0x00,0x70,0x00,0x30,0x40,0x00,0x00};
+const unsigned int BRSTM_formats_audio_off_off[BRSTM_formats_count] = {0x00,0x70,0x00,0x30,0x40,0x00};
 //Offset to the codec information and their sizes in each format
-const unsigned int BRSTM_formats_codec_off  [BRSTM_formats_count] = {0x00,0x60,0x00,0x60,0x10,0x00,0x00};
-const unsigned int BRSTM_formats_codec_bytes[BRSTM_formats_count] = {1,1,1,1,2,1,1};
+const unsigned int BRSTM_formats_codec_off  [BRSTM_formats_count] = {0x00,0x60,0x00,0x60,0x10,0x00};
+const unsigned int BRSTM_formats_codec_bytes[BRSTM_formats_count] = {1,1,1,1,2,1};
 //Short human readable strings (equal to file extension)
-const char* BRSTM_formats_short_usr_str[BRSTM_formats_count] = {"None","BRSTM","BCSTM","BFSTM","BWAV","ORSTM","WAV"};
+const char* BRSTM_formats_short_usr_str[BRSTM_formats_count] = {"WAV","BRSTM","BCSTM","BFSTM","BWAV","ORSTM"};
 //Long human readable strings
 const char* BRSTM_formats_long_usr_str [BRSTM_formats_count] = {
-"Unknown format",
+"Waveform Audio",
 "Binary Revolution Stream",
 "Binary CTR Stream",
 "Binary Cafe Stream",
 "Nintendo BWAV",
-"Open Revolution Stream",
-"Waveform Audio"
+"Open Revolution Stream"
 };
 
 //Codec information

--- a/src/lib/brstm.h
+++ b/src/lib/brstm.h
@@ -378,17 +378,24 @@ void brstm_getbuffer_main(Brstm * brstmi,const unsigned char* fileData,bool data
                 brstmi->PCM_buffer[c][p] = brstmi->PCM_blockbuffer[c][dataIndex+p];
             }
         }
-        if(blockEndReached) {
+        while(blockEndReached) {
+            blockEndReached = false;
             //safety, return if we are outside the last block
             if((sampleOffset+blockEndReachedAt)/brstmi->blocks_samples >= brstmi->total_blocks) return;
             //don't make a new buffer in PCM_buffer
             brstmi->getbuffer_useBuffer = false;
             brstm_getbuffer_main(brstmi,fileData,dataType,sampleOffset+blockEndReachedAt,0);
             brstmi->getbuffer_useBuffer = true;
+            unsigned int newstart = blockEndReachedAt;
             for(unsigned int c=0;c<brstmi->num_channels;c++) {
                 unsigned int dataIndex=0;
-                for(unsigned int p=blockEndReachedAt;p<bufferSamples;p++) {
+                for(unsigned int p=newstart;p<bufferSamples;p++) {
                     brstmi->PCM_buffer[c][p] = brstmi->PCM_blockbuffer[c][dataIndex++];
+                    if(dataIndex >= brstmi->blocks_samples) {
+                        blockEndReached = true;
+                        blockEndReachedAt = ++p;
+                        break;
+                    }
                 }
             }
         }

--- a/src/lib/brstm.h
+++ b/src/lib/brstm.h
@@ -13,17 +13,17 @@ const char* BRSTM_version_str = "v2.2.0";
 const char* brstm_getVersionString() {return BRSTM_version_str;}
 
 //Format information
-const unsigned int BRSTM_formats_count = 6;
+const unsigned int BRSTM_formats_count = 7;
 //File header magic words for each file format
-const char* BRSTM_formats_str[BRSTM_formats_count] = {"    ","RSTM","CSTM","FSTM","BWAV","OSTM"};
+const char* BRSTM_formats_str[BRSTM_formats_count] = {"    ","RSTM","CSTM","FSTM","BWAV","OSTM","RIFF"};
 //Offset to the audio offset information in each format (32 bit integer)
 //(doesn't have to be accurate, just enough to fit the entire file header before it)
-const unsigned int BRSTM_formats_audio_off_off[BRSTM_formats_count] = {0x00,0x70,0x00,0x30,0x40,0x00};
+const unsigned int BRSTM_formats_audio_off_off[BRSTM_formats_count] = {0x00,0x70,0x00,0x30,0x40,0x00,0x00};
 //Offset to the codec information and their sizes in each format
-const unsigned int BRSTM_formats_codec_off  [BRSTM_formats_count] = {0x00,0x60,0x00,0x60,0x10,0x00};
-const unsigned int BRSTM_formats_codec_bytes[BRSTM_formats_count] = {1,1,1,1,2,1};
-//Short human readable strings
-const char* BRSTM_formats_short_usr_str[BRSTM_formats_count] = {"None","BRSTM","BCSTM","BFSTM","BWAV","ORSTM"};
+const unsigned int BRSTM_formats_codec_off  [BRSTM_formats_count] = {0x00,0x60,0x00,0x60,0x10,0x00,0x00};
+const unsigned int BRSTM_formats_codec_bytes[BRSTM_formats_count] = {1,1,1,1,2,1,1};
+//Short human readable strings (equal to file extension)
+const char* BRSTM_formats_short_usr_str[BRSTM_formats_count] = {"None","BRSTM","BCSTM","BFSTM","BWAV","ORSTM","WAV"};
 //Long human readable strings
 const char* BRSTM_formats_long_usr_str [BRSTM_formats_count] = {
 "Unknown format",
@@ -31,7 +31,8 @@ const char* BRSTM_formats_long_usr_str [BRSTM_formats_count] = {
 "Binary CTR Stream",
 "Binary Cafe Stream",
 "Nintendo BWAV",
-"Open Revolution Stream"
+"Open Revolution Stream",
+"Waveform Audio"
 };
 
 //Codec information

--- a/src/lib/d_formats/all.h
+++ b/src/lib/d_formats/all.h
@@ -1,10 +1,12 @@
 //Include all formats
+#include "wav.h"
 #include "brstm.h"
 #include "bcstm.h"
 #include "bfstm.h"
 #include "bwav.h"
 #include "orstm.h"
 
+unsigned char brstm_formats_read_wav  (Brstm* brstmi,const unsigned char* fileData,signed int debugLevel,uint8_t decodeAudio);
 unsigned char brstm_formats_read_brstm(Brstm* brstmi,const unsigned char* fileData,signed int debugLevel,uint8_t decodeAudio);
 unsigned char brstm_formats_read_bcstm(Brstm* brstmi,const unsigned char* fileData,signed int debugLevel,uint8_t decodeAudio);
 unsigned char brstm_formats_read_bfstm(Brstm* brstmi,const unsigned char* fileData,signed int debugLevel,uint8_t decodeAudio);

--- a/src/lib/d_formats/wav.h
+++ b/src/lib/d_formats/wav.h
@@ -59,7 +59,8 @@ unsigned char brstm_formats_read_wav(Brstm* brstmi,const unsigned char* fileData
     }
     if(brstmi->num_tracks>1 && debugLevel>=0) {std::cout << "Warning: Track information is guessed\n";}
     
-    { //Read audio from wav file
+    if(decodeAudio == 1) {
+        //Read audio from wav file
         unsigned int c;
         for(c=0;c<brstmi->num_channels;c++) {
             brstmi->PCM_samples[c] = new int16_t[brstmi->total_samples];
@@ -69,6 +70,11 @@ unsigned char brstm_formats_read_wav(Brstm* brstmi,const unsigned char* fileData
                 brstmi->PCM_samples[c][i] = brstm_getSliceAsInt16Sample(fileData,wavAudioOffset+i*(2*brstmi->num_channels)+c*2,0);
             }
         }
+    } else if(decodeAudio == 2) {
+        if(debugLevel>=0) std::cout << "Cannot write raw ADPCM data because the codec is not ADPCM.\n";
+        return 220;
+    } else if(decodeAudio == 0) {
+        if(debugLevel>=0) std::cout << "Warning: Realtime decoding may not work correctly for this format\n";
     }
     return 0;
 }

--- a/src/lib/d_formats/wav.h
+++ b/src/lib/d_formats/wav.h
@@ -2,5 +2,73 @@
 //Copyright (C) 2020 Extrasklep
 
 unsigned char brstm_formats_read_wav(Brstm* brstmi,const unsigned char* fileData,signed int debugLevel,uint8_t decodeAudio) {
-    return 210;
+    //Read the WAV file data
+    if(strcmp("RIFF",brstm_getSliceAsString(fileData,0,4)) != 0) {
+        if(debugLevel>=0) std::cout << "Invalid RIFF header.\n";
+        return 255;
+    }
+    unsigned long wavFileSize = brstm_getSliceAsNumber(fileData,4,4,0) + 8;
+    if(strcmp("WAVEfmt ",brstm_getSliceAsString(fileData,8,8)) != 0) {
+        if(debugLevel>=0) std::cout << "Invalid WAVE header.\n";
+        return 255;
+    }
+    unsigned long wavFmtSize = brstm_getSliceAsNumber(fileData,16,4,0);
+    if(wavFmtSize != 16 || brstm_getSliceAsNumber(fileData,20,2,0) != 1) {
+        if(debugLevel>=0) std::cout << "Only PCM WAVs are supported.\n";
+        return 220;
+    }
+    brstmi->num_channels = brstm_getSliceAsNumber(fileData,22,2,0);
+    if(brstmi->num_channels > 16) {
+        if(debugLevel>=0) std::cout << "Too many channels. Max supported is 16.\n";
+        return 249;
+    }
+    brstmi->sample_rate = brstm_getSliceAsNumber(fileData,24,4,0);
+    if(brstm_getSliceAsNumber(fileData,34,2,0) != 16) {
+        if(debugLevel>=0) std::cout << "Only 16-bit PCM WAVs are supported.\n";
+        return 220;
+    }
+    unsigned long wavAudioOffset = 36;
+    for(;strcmp("data",brstm_getSliceAsString(fileData,wavAudioOffset,4)) != 0 ;wavAudioOffset++) {}
+    brstmi->total_samples = brstm_getSliceAsNumber(fileData,wavAudioOffset+4,4,0) / brstmi->num_channels / 2;
+    wavAudioOffset += 8;
+    
+    //Write some standard information to BRSTM struct
+    brstmi->codec = 1;
+    brstmi->loop_flag = 0;
+    brstmi->loop_start = 0;
+    brstmi->audio_offset = wavAudioOffset;
+    brstmi->total_blocks = brstmi->total_samples;
+    brstmi->blocks_size = 2;
+    brstmi->blocks_samples = 1;
+    brstmi->final_block_size = 2;
+    brstmi->final_block_samples = 1;
+    brstmi->final_block_size_p = 2;
+    
+    //Write standard track information
+    brstmi->num_tracks = (brstmi->num_channels > 1 && brstmi->num_channels%2 == 0) ? brstmi->num_channels/2 : brstmi->num_channels;
+    if(brstmi->num_tracks > 8) {
+        if(debugLevel>=0) {std::cout << "Too many tracks, Max supported is 8.\n";}
+        return 248;
+    }
+    unsigned char track_num_channels = brstmi->num_tracks*2 == brstmi->num_channels ? 2 : 1;
+    brstmi->track_desc_type = 0;
+    for(unsigned char c=0; c<brstmi->num_channels; c++) {
+        brstmi->track_num_channels[c/track_num_channels] = track_num_channels;
+        if(track_num_channels == 1 || c%2 == 0) brstmi->track_lchannel_id[c/track_num_channels] = c;
+        if(track_num_channels == 2 && c%2 == 1) brstmi->track_rchannel_id[c/track_num_channels] = c;
+    }
+    if(brstmi->num_tracks>1 && debugLevel>=0) {std::cout << "Warning: Track information is guessed\n";}
+    
+    { //Read audio from wav file
+        unsigned int c;
+        for(c=0;c<brstmi->num_channels;c++) {
+            brstmi->PCM_samples[c] = new int16_t[brstmi->total_samples];
+        }
+        for(unsigned int i=0;i<brstmi->total_samples;i++) {
+            for(c=0;c<brstmi->num_channels;c++) {
+                brstmi->PCM_samples[c][i] = brstm_getSliceAsInt16Sample(fileData,wavAudioOffset+i*(2*brstmi->num_channels)+c*2,0);
+            }
+        }
+    }
+    return 0;
 }

--- a/src/lib/d_formats/wav.h
+++ b/src/lib/d_formats/wav.h
@@ -1,0 +1,6 @@
+//OpenRevolution WAV reader
+//Copyright (C) 2020 Extrasklep
+
+unsigned char brstm_formats_read_wav(Brstm* brstmi,const unsigned char* fileData,signed int debugLevel,uint8_t decodeAudio) {
+    return 210;
+}

--- a/src/lib/e_formats/all.h
+++ b/src/lib/e_formats/all.h
@@ -1,10 +1,12 @@
 //Include all formats
+#include "wav.h"
 #include "brstm.h"
 #include "bcstm.h"
 #include "bfstm.h"
 #include "bwav.h"
 #include "orstm.h"
 
+unsigned char brstm_formats_encode_wav  (Brstm* brstmi,signed int debugLevel,uint8_t encodeADPCM);
 unsigned char brstm_formats_encode_brstm(Brstm* brstmi,signed int debugLevel,uint8_t encodeADPCM);
 unsigned char brstm_formats_encode_bcstm(Brstm* brstmi,signed int debugLevel,uint8_t encodeADPCM);
 unsigned char brstm_formats_encode_bfstm(Brstm* brstmi,signed int debugLevel,uint8_t encodeADPCM);

--- a/src/lib/e_formats/wav.h
+++ b/src/lib/e_formats/wav.h
@@ -1,0 +1,6 @@
+//OpenRevolution WAV writer
+//Copyright (C) 2020 Extrasklep
+
+unsigned char brstm_formats_encode_wav(Brstm* brstmi,signed int debugLevel,uint8_t encodeADPCM) {
+    return 210;
+}


### PR DESCRIPTION
- Audio stream format support (standard blocked data or interleaved WAV samples)
- WAV reading support with realtime decoding/streaming
- getbuffer can now work with infinite buffer sizes
- brstm_converter still uses it's own WAV reader and writer